### PR TITLE
Fix params.yaml

### DIFF
--- a/exampleSite/config/production/params.yaml
+++ b/exampleSite/config/production/params.yaml
@@ -1,2 +1,2 @@
 # see https://hugomods.com/en/docs/google-adsense/.
-# google_adsense = 'ca-pub-XXXXXXXXXXXXXXXX' # Please make that the Google AdSense module was imported.
+# google_adsense: 'ca-pub-XXXXXXXXXXXXXXXX' # Please make that the Google AdSense module was imported.


### PR DESCRIPTION
Correct YAML format. Equals sign is used in TOML.

Otherwise, when you activate this option you'll get this error: 

`failed to unmarshal YAML`